### PR TITLE
Use distroless Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM python:slim-bullseye
+# Stage 1: Copy all files into the build-env container
+FROM python:3-slim AS build-env
+COPY . /app
+RUN pip install --no-cache-dir -r /app/requirements.txt
+WORKDIR /app
 
-COPY requirements.txt ./
-COPY tracepusher.py ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Stage 2: Use Google distroless and only copy in the app files
+FROM gcr.io/distroless/python3
+
+COPY --from=build-env /app /app
+# Copy site-packages (which contains the 'requests' module from 'build-env' into the new image)
+COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+WORKDIR /app
+# Make sure Python knows where to find the 'requests' module
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 
 ENTRYPOINT ["python", "./tracepusher.py"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ eg. python tracepusher.py http://localhost:4318 tracepusher my-span 2
 or:
 
 ```
-docker run gardnera/tracepusher:v0.3.0 http(s)://OTEL-COLLECTOR-ENDPOINT:4318 service_name span_name SPAN_TIME_IN_SECONDS
+docker run gardnera/tracepusher:v0.3.1 http(s)://OTEL-COLLECTOR-ENDPOINT:4318 service_name span_name SPAN_TIME_IN_SECONDS
 ```
 
 ## Dry Run Mode


### PR DESCRIPTION
This PR:

- Resolves #8 
- [Uses Google's Python "distroless" image to shrink the final container](https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3/Dockerfile)
- [Is tagged as `gardnera/tracepusher:v0.3.1`](https://hub.docker.com/r/gardnera/tracepusher/tags?page=1&name=v0.3.1)