### PR TITLE
add attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,46 +16,49 @@ Generate and push OpenTelemetry Trace data to an endpoint in JSON format.
 
 ```
 python tracepusher.py \
---endpoint=http(s)://OTEL-COLLECTOR-ENDPOINT:4318
---service-name=service_name \
---span-name=spanA \
---duration=2
+--endpoint http(s)://OTEL-COLLECTOR-ENDPOINT:4318
+--service-name service_name \
+--span-name spanA \
+--duration 2
 ```
 
 ## Docker Usage
 
 ```
 docker run gardnera/tracepusher:v0.5.0 \
--ep=http(s)://OTEL-COLLECTOR-ENDPOINT:4318 \
--sen=service_name \
--spn=span_name \
--dur=SPAN_TIME_IN_SECONDS
+-ep http(s)://OTEL-COLLECTOR-ENDPOINT:4318 \
+-sen service_name \
+-spn span_name \
+-dur SPAN_TIME_IN_SECONDS
 ```
 
 ### Optional Parameters:
 ```
---dry-run=True|False
---debug=True|False
---time-shift=True|False
---parent-span-id=<16 character hex id>
---trace-id=<32 character hex id>
---span-id=<16 character hex id>
+--dry-run True|False
+--debug True|False
+--time-shift True|False
+--parent-span-id <16 character hex id>
+--trace-id <32 character hex id>
+--span-id <16 character hex id>
+--span-attributes key=value [key2=value2...]
 ```
 
-Use the final 3 optional parameters above when working with sub spans. See below for more information.
+Use `parent-span-id` `trace-id` and `span-id` optional parameters when working with sub spans. See below for more information.
+
+Use `span-attributes` to add `key=value` pairs of [span attributes](https://opentelemetry.io/docs/instrumentation/python/manual/#add-attributes-to-a-span) to your span. See below for more information.
 
 ## Dry Run Mode
-Add `--dr=True`, `--dry-run=True` or `--dry=True` to run without actually pushing any data.
+Add `--dr=True`, `--dry-run True` or `--dry True` to run without actually pushing any data.
 
 ## Debug Mode
-Add `-x=True` or `--debug=True` for extra output
+Add `-x True` or `--debug True` for extra output
 
 ## Time Shifting
 In "default mode" tracepusher starts a trace `now` and finishes it `SPAN_TIME_IN_SECONDS` in the future.
 
 You may want to push timings for traces that have already occurred (eg. shell scripts). See https://github.com/agardnerIT/tracepusher/issues/4.
 
-`--time-shift=True` means `start` and `end` times will be shifted back by whatever is specified as the `--duration`.
+`--time-shift True` means `start` and `end` times will be shifted back by whatever is specified as the `--duration`.
 
 ## Complex Tracing (Sub Span support)
 ![subspan schematic](assets/subspan.schematic.excalidraw.png)
@@ -100,13 +103,13 @@ The parent span would look like the following. Notice the `--time-shift=True` pa
 ### Parent Span Example
 ```
 python3 tracepusher.py \
-    --endpoint=http://localhost:4318 \
-    --service-name="serviceA" \
-    --span-name="main_span" \
-    --duration=${duration} \
-    --trace-id=${trace_id} \
-    --span-id=${span_id} \
-    --time-shift=True
+    --endpoint http://localhost:4318 \
+    --service-name "serviceA" \
+    --span-name "main_span" \
+    --duration ${duration} \
+    --trace-id ${trace_id} \
+    --span-id ${span_id} \
+    --time-shift True
 ```
 
 ### Sub Span Example
@@ -126,15 +129,52 @@ do
   counter=$(( $counter + 1 ))
 
   python3 tracepusher.py \
-    --endpoint=http://localhost:4318 \
-    --service-name=serviceA \
-    --span-name="subspan${counter}" \
-    --duration=${duration} \
-    --trace-id=${trace_id} \
-    --parent-span-id=${span_id} \
-    --span-id=${subspan_id} \
-    --time-shift=True
+    --endpoint http://localhost:4318 \
+    --service-name serviceA \
+    --span-name "subspan${counter}" \
+    --duration ${duration} \
+    --trace-id ${trace_id} \
+    --parent-span-id ${span_id} \
+    --span-id ${subspan_id} \
+    --time-shift True
 done
+```
+
+## Span Attributes
+
+The optional `-spnattrs` or equivalent long form version: `--span-attributes` exists to add span attributes to the spans that tracepusher creates.
+
+Add as many attributes as you like.
+
+### Formatting Span Attributes
+
+Tracepusher will accept two possible inputs:
+
+- `--span-attributes foo=bar`
+- `--span-attributes foo=bar=<TYPE>`
+
+In the first, the value is assumed to be of type `stringValue`.
+
+In the second, **you** specify the value type. Possible types are: `stringValue`... TODO when [this is answered](https://cloud-native.slack.com/archives/CJFCJHG4Q/p1685167286427639).
+
+Separate each attribute with a space.
+
+```
+python tracepusher.py \
+--endpoint http(s)://OTEL-COLLECTOR-ENDPOINT:4318
+--service-name service_name \
+--span-name spanA \
+--duration 2 \
+--span-attributes foo=bar foo2=bar2=stringValue
+```
+
+```
+docker run gardnera/tracepusher:v0.5.0 \
+-ep http(s)://OTEL-COLLECTOR-ENDPOINT:4318 \
+-sen service_name \
+-spn span_name \
+-dur SPAN_TIME_IN_SECONDS \
+--spnattrs foo=bar foo2=bar2=stringValue
 ```
 
 ## Spin up OpenTelemetry Collector

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Tracepusher will accept two possible inputs:
 
 In the first, the value is assumed to be of type `stringValue`.
 
-In the second, **you** specify the value type. Possible types are: `stringValue`... TODO when [this is answered](https://cloud-native.slack.com/archives/CJFCJHG4Q/p1685167286427639).
+In the second, **you** specify the value type. Possible types are: `stringValue`, `boolValue`, `intValue`, `doubleValue`, `arrayValue`, `kvlistValue` or `bytesValue`.
 
 Separate each attribute with a space.
 
@@ -175,7 +175,7 @@ python tracepusher.py \
 --service-name service_name \
 --span-name spanA \
 --duration 2 \
---span-attributes foo=bar foo2=bar2=stringValue
+--span-attributes foo=bar foo2=23=intValue
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -279,9 +279,10 @@ Argument handling was entirely re-written for `v0.4.0` and `tracepusher` expects
 Run all build commands from the root directory:
 
 ```
-docker build -t tracepusher:dev-ci -f ./docker/ci/Dockerfile .
-docker build -t tracepusher:dev -f ./docker/standard/Dockerfile .
+docker buildx build --platform linux/arm64,linux/amd64 --push -t tracepusher:dev-ci ./docker/ci/Dockerfile .
+docker buildx build --platform linux/arm64,linux/amd64 --push -t tracepusher:dev -f ./docker/standard/Dockerfile .
 ```
+
 ----------------------
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Argument handling was entirely re-written for `v0.4.0` and `tracepusher` expects
 Run all build commands from the root directory:
 
 ```
-docker buildx build --platform linux/arm64,linux/amd64 --push -t tracepusher:dev-ci ./docker/ci/Dockerfile .
+docker buildx build --platform linux/arm64,linux/amd64 --push -t tracepusher:dev-ci -f ./docker/ci/Dockerfile .
 docker buildx build --platform linux/arm64,linux/amd64 --push -t tracepusher:dev -f ./docker/standard/Dockerfile .
 ```
 

--- a/tracepusher.py
+++ b/tracepusher.py
@@ -24,7 +24,7 @@ import argparse
 #         }
 # Ref: https://github.com/open-telemetry/opentelemetry-proto/blob/9876ebfc5bcf629d1438d1cf1ee8a1a4ec21676c/examples/trace.json#L20-L56
 # Values must be a non-null string, boolean, floating point value, integer, or an array of these values
-# [{"key": "foo", "value": "bar"}, {"key": "foo2": "value": "bar2"} ...]
+# stringValue, boolValue, intValue, doubleValue, arrayValue, kvlistValue, bytesValue are all valid
 def get_span_attributes_list(args):
 
     arg_list = []


### PR DESCRIPTION
This PR:

- Adds tracepusher support for sending span attributes

## TODO (seperate PR)

The OpenTelemetry docs only show `stringValue` as a possible type, but hint at floats, ints and arrays being allowed too.
- Asked in Slack. Wait for a resolution to [this thread](https://cloud-native.slack.com/archives/CJFCJHG4Q/p1685167286427639)
- Update code + readme