### PR TITLE
replaced all CLI examples to `true`[Fixes #19]

### DIFF
--- a/docs/reference/debug-mode.md
+++ b/docs/reference/debug-mode.md
@@ -1,2 +1,3 @@
 ## Debug Mode
-Add `-x True` or `--debug True` for extra output
+
+Add `-x true` or `--debug true` for extra output

--- a/docs/reference/dry-run-mode.md
+++ b/docs/reference/dry-run-mode.md
@@ -1,2 +1,3 @@
 ## Dry Run Mode
-Add `--dr True`, `--dry-run True` or `--dry True` to run without actually pushing any data.
+
+Add `--dr true`, `--dry-run true` or `--dry true` to run without actually pushing any data.

--- a/docs/reference/multi-span-traces.md
+++ b/docs/reference/multi-span-traces.md
@@ -35,11 +35,13 @@ In the default mode, tracepusher will auto-generate trace and span IDs but you c
 trace_id=$(hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom)
 span_id=$(hexdump -vn8 -e'4/4 "%08X" 1 "\n"' /dev/urandom)
 ```
-The parent span would look like the following. Notice the `--time-shift=True` parameter is set. If this **was not** set, the timings would not make sense.
+
+The parent span would look like the following. Notice the `--time-shift=true` parameter is set. If this **was not** set, the timings would not make sense.
 
 For more information, see [time shifting](time-shifting.md)
 
 ### Parent Span Example
+
 ```
 python3 tracepusher.py \
     --endpoint http://localhost:4318 \
@@ -52,6 +54,7 @@ python3 tracepusher.py \
 ```
 
 ### Sub Span Example
+
 ```
 # Note: subspan time is tracked independently to "main" span time
 while [ $counter -lt $limit ]
@@ -62,7 +65,7 @@ do
 
   # Do real work here...
   sleep 1
-  
+
   subspan_time_end=$SECONDS
   duration=$$(( $time_end - $time_start ))
   counter=$(( $counter + 1 ))

--- a/docs/reference/time-shifting.md
+++ b/docs/reference/time-shifting.md
@@ -4,4 +4,4 @@ In "default mode" tracepusher starts a trace `now` and finishes it `SPAN_TIME_IN
 
 You may want to push timings for traces that have already occurred (eg. shell scripts). See https://github.com/agardnerIT/tracepusher/issues/4.
 
-`--time-shift True` means `start` and `end` times will be shifted back by whatever is specified as the `--duration`.
+`--time-shift true` means `start` and `end` times will be shifted back by whatever is specified as the `--duration`.


### PR DESCRIPTION
Fixes #19

Since it is the CLI, it would always be more efficient ot use `true` rather than `True`. So I replaced all instances in the docs.