### PR TITLE
Emphasize on using the CI tagged image in GitLab example

### DIFF
--- a/samples/gitlab/.gitlab-ci.yml
+++ b/samples/gitlab/.gitlab-ci.yml
@@ -1,9 +1,12 @@
 image:
-  name: gardnera/tracepusher:v0.5.0-ci
+  # Important: Specify the CI tagged image which provides a shell, and has no entrypoint.
+  name: gardnera/tracepusher:v0.7.0-ci
 
-# Set your OTEL collector endpoint address here...
 variables:
+  # Set your OTEL collector endpoint address here...
   OTEL_COLLECTOR_ENDPOINT: "http://1.2.3.4:4318"
+  # Debug the job execution steps
+  #CI_DEBUG_TRACE: "true"
 
 stages:
   - preparation


### PR DESCRIPTION
I did not recognize in my first tests that a specific CI tagged image needs to be used, and went with manually editing my configuration with the default image. 

This led to some debugging because launching the container image in CI/CD always executed the script as entrypoint. I first suspected the `after_script` default config because this also invokes the script. 

This PR 

1. Adds a comment that emphasizes on the CI tagged image
2. Bumps the image tag to the latest 0.7.0-ci tag
3. Adds a variable for debugging CI/CD jobs (`CI_DEBUG_TRACE`) which is disabled by default. 

Tests and learning steps in https://gitlab.com/gitlab-de/use-cases/observability/devsecops-efficiency/slow-pipeline-for-analysis/-/merge_requests/1 
