### PR TITLE
Create build_standalone_binaries.yml

### DIFF
--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -1,6 +1,8 @@
 name: Build Binaries
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "main"
 
 jobs:
   win_build_binary:
@@ -32,7 +34,7 @@ jobs:
           git push
   linux_x64_build_binary:
     name: "[LIN x64] Build Self Contained Binary"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -1,0 +1,62 @@
+name: Build Binaries
+on:
+  workflow_dispatch:
+
+jobs:
+  win_build_binary:
+    name: "[WIN] Build Self Contained Binary"
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+      - name: Install Python and Pip Packages
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.4'
+          cache: 'pip'
+      - name: "Install Dependencies"
+        run: pip install -r requirements.txt
+      - name: "Build Binary"
+        run: "python -m PyInstaller --onefile tracepusher.py"
+      - name: "Setup git Config"
+        run: >
+          git config user.name "GitHub Actions Bot" &&
+          git config user.email "<>"
+      - name: "Add Binary to Repo"
+        run: >
+          git add dist/tracepusher.exe &&
+          git commit -m "add tracepusher.exe" &&
+          git pull &&
+          git push
+  linux_x64_build_binary:
+    name: "[LIN x64] Build Self Contained Binary"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+      - name: Install Python and Pip Packages
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.4'
+          cache: 'pip'
+      - name: "Install Dependencies"
+        run: pip install -r requirements.txt
+      - name: "Build Binary"
+        run: "python -m PyInstaller --onefile tracepusher.py"
+      - name: "Rename file"
+        run: "mv dist/tracepusher dist/tracepusher_linux_x64"
+      - name: "Setup git Config"
+        run: >
+          git config user.name "GitHub Actions Bot" &&
+          git config user.email "<>"
+      - name: "Add Binary to Repo"
+        run: >
+          git add dist/tracepusher_linux_x64 &&
+          git commit -m "add tracepusher_linux_x64 binary" &&
+          git pull &&
+          git push
+# TODO: Add ARM for MacOS runner when this is available: https://github.com/github/roadmap/issues/528


### PR DESCRIPTION
This PR:

Adds a manually triggered (`workflow_dispatch`) Actions workflow which:

- Builds the windows standalone binary using PyInstaller
- Builds the Linux x64 standalone binary using PyInstaller

TODO: Separate PR: Add support for macOS Apple Silicon when https://github.com/github/roadmap/issues/528 is done (Q4 2023)

Relates to #37